### PR TITLE
Rename EURail endpoint

### DIFF
--- a/lib/journeys.js
+++ b/lib/journeys.js
@@ -116,7 +116,7 @@ const journeys = async (origin, destination, opt = {}) => {
 	let journeys = []
 	// eslint-disable-next-line no-labels
 	fetchJourneys: do {
-		const endpoint = 'https://timetable.eurail.com/v1/timetable/trip'
+		const endpoint = 'https://api.eurail.com/timetable/trip'
 		const query = stringify({
 			lang: options.language,
 			originId: formatInputId(origin),

--- a/lib/stations.js
+++ b/lib/stations.js
@@ -40,7 +40,7 @@ const search = async (query, opt = {}) => {
 	const options = merge({}, defaults, opt)
 	validateArguments(query, options)
 
-	const endpoint = 'https://timetable.eurail.com/v1/timetable/location.name'
+	const endpoint = 'https://api.eurail.com/timetable/location.name'
 	const httpQuery = stringify({ input: query })
 	const url = `${endpoint}?${httpQuery}`
 

--- a/test.js
+++ b/test.js
@@ -42,6 +42,11 @@ tape('interrail.journeys', async t => {
 		id: '7942300',
 		name: 'Ljubljana'
 	}
+	const hamburg = {
+		type: 'station',
+		id: '8002710',
+		name: 'Hamburg'
+	}
 	const when = DateTime.fromJSDate(new Date(), { zone: 'Europe/Berlin' }).plus({ days: 10 }).startOf('day').plus({ hours: 5 }).toJSDate()
 	const journeys = await interrail.journeys(berlin, ljubljana, { when })
 
@@ -68,7 +73,7 @@ tape('interrail.journeys', async t => {
 
 	const twoDaysLater = DateTime.fromJSDate(when).plus({ days: 2 }).toJSDate()
 	const threeDays = 3 * 24 * 60
-	const manyJourneys = await interrail.journeys(ljubljana, berlin, { when, interval: threeDays })
+	const manyJourneys = await interrail.journeys(hamburg, berlin, { when, interval: threeDays })
 	t.ok(manyJourneys.length > 10, 'number of journeys')
 	const journeysTwoDaysLater = manyJourneys.filter(j => +new Date(j.legs[0].departure) > +twoDaysLater)
 	t.ok(journeysTwoDaysLater.length >= 2, 'number of journeys')


### PR DESCRIPTION
The old endpoint stopped working.
Compare: https://api.eurail.com/timetable/location.name?input=berlin / https://timetable.eurail.com/v1/timetable/location.name?input=berlin